### PR TITLE
Add support of DeliveryApi - Fix IsValue function to Check if the value is a stringified List of KeyAndValue object 

### DIFF
--- a/src/V10/KeyValuePropertyConverter.cs
+++ b/src/V10/KeyValuePropertyConverter.cs
@@ -27,7 +27,9 @@ namespace Vokseverk {
 		public bool? IsValue(object value, PropertyValueLevel level) {
 			switch (level) {
 				case PropertyValueLevel.Source:
-					return value != null && value is List<KeyAndValue>;
+					    return value != null &&
+                        (value is List<KeyAndValue> ||
+                        (value is string strValue && strValue.DetectIsJson() && JsonConvert.DeserializeObject<List<KeyAndValue>>(strValue) is List<KeyAndValue>));
 				default:
 					throw new NotSupportedException($"Invalid level: {level}.");
 			}


### PR DESCRIPTION
Resolves #9 

The function _IsValue_ now also checks if the passed value is a stringified string of List<KeyAndValue> and if so, it returns true, which allows deserializing the list by the content delivery API to return the list of key value pairs instead of null

**Example input:** 

![image](https://github.com/user-attachments/assets/237ca57c-7284-4a87-b9f4-f9f8a77dd379)

**Output:**

![image](https://github.com/user-attachments/assets/59afe4e0-b9fa-4158-89e6-f768711478ba)

```diff
           public bool? IsValue(object value, PropertyValueLevel level) {
			switch (level) {
				case PropertyValueLevel.Source:
-					return value != null && value is List<KeyAndValue>;
```

```diff
		public bool? IsValue(object value, PropertyValueLevel level) {
			switch (level) {
				case PropertyValueLevel.Source:
+				    return value != null &&
+                                     (value is List<KeyAndValue> ||
+                                     (value is string strValue && strValue.DetectIsJson() && JsonConvert.DeserializeObject<List<KeyAndValue>>(strValue) is List<KeyAndValue>));
```

